### PR TITLE
Use structs, for easier testing(?)

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -2,36 +2,46 @@ package events
 
 import (
 	"fmt"
-	"github.com/cloudfoundry-community/firehose-to-syslog/logging"
+	"github.com/Sirupsen/logrus"
+	"github.com/cloudfoundry-community/firehose-to-syslog/caching"
 	"github.com/cloudfoundry/noaa/events"
 	"os"
 	"strings"
 )
 
+type Event struct {
+	Fields logrus.Fields
+	Msg    string
+}
+
 func RouteEvents(in chan *events.Envelope, selectedEvents map[string]bool) {
 	for msg := range in {
 		eventType := msg.GetEventType()
 		if selectedEvents[eventType.String()] {
+			var event Event
 			switch eventType {
 			case events.Envelope_Heartbeat:
-				logging.Heartbeats(msg)
+				event = Heartbeat(msg)
 			case events.Envelope_HttpStart:
-				logging.HttpStarts(msg)
+				event = HttpStart(msg)
 			case events.Envelope_HttpStop:
-				logging.HttpStops(msg)
+				event = HttpStop(msg)
 			case events.Envelope_HttpStartStop:
-				logging.HttpStartStops(msg)
+				event = HttpStartStop(msg)
 			case events.Envelope_LogMessage:
-				logging.LogMessages(msg)
+				event = LogMessage(msg)
 			case events.Envelope_ValueMetric:
-				logging.ValueMetrics(msg)
+				event = ValueMetric(msg)
 			case events.Envelope_CounterEvent:
-				logging.CounterEvents(msg)
+				event = CounterEvent(msg)
 			case events.Envelope_Error:
-				logging.ErrorEvents(msg)
+				event = ErrorEvent(msg)
 			case events.Envelope_ContainerMetric:
-				logging.ContainerMetrics(msg)
+				event = ContainerMetric(msg)
 			}
+
+			event.AnnotateWithAppData()
+			event.Log()
 		}
 	}
 }
@@ -42,7 +52,7 @@ func GetSelectedEvents(wantedEvents string) map[string]bool {
 		if isAuthorizedEvent(event) {
 			selectedEvents[event] = true
 		} else {
-			fmt.Fprintf(os.Stderr, "Rejected Event Name %s", event)
+			fmt.Fprintf(os.Stderr, "Rejected Event Name %s\n", event)
 		}
 	}
 	// If any event is not authorize we fallback to the default one
@@ -68,4 +78,229 @@ func GetListAuthorizedEventEvents() (authorizedEvents string) {
 	}
 	return strings.Join(arrEvents, ", ")
 
+}
+
+func getAppInfo(appGuid string) caching.App {
+	if app := caching.GetAppInfo(appGuid); app.Name != "" {
+		return app
+	} else {
+		caching.GetAppByGuid(appGuid)
+	}
+	return caching.GetAppInfo(appGuid)
+}
+
+func Heartbeat(msg *events.Envelope) Event {
+	heartbeat := msg.GetHeartbeat()
+
+	fields := logrus.Fields{
+		"ctl_msg_id":     heartbeat.GetControlMessageIdentifier(),
+		"error_count":    heartbeat.GetErrorCount(),
+		"event_type":     msg.GetEventType().String(),
+		"origin":         msg.GetOrigin(),
+		"received_count": heartbeat.GetReceivedCount(),
+		"sent_count":     heartbeat.GetSentCount(),
+	}
+
+	return Event{
+		Fields: fields,
+		Msg:    "",
+	}
+}
+
+func HttpStart(msg *events.Envelope) Event {
+	httpStart := msg.GetHttpStart()
+
+	fields := logrus.Fields{
+		"event_type":        msg.GetEventType().String(),
+		"origin":            msg.GetOrigin(),
+		"cf_app_id":         httpStart.GetApplicationId(),
+		"instance_id":       httpStart.GetInstanceId(),
+		"instance_index":    httpStart.GetInstanceIndex(),
+		"method":            httpStart.GetMethod(),
+		"parent_request_id": httpStart.GetParentRequestId(),
+		"peer_type":         httpStart.GetPeerType(),
+		"request_id":        httpStart.GetRequestId(),
+		"remote_addr":       httpStart.GetRemoteAddress(),
+		"timestamp":         httpStart.GetTimestamp(),
+		"uri":               httpStart.GetUri(),
+		"user_agent":        httpStart.GetUserAgent(),
+	}
+
+	return Event{
+		Fields: fields,
+		Msg:    "",
+	}
+}
+
+func HttpStop(msg *events.Envelope) Event {
+	httpStop := msg.GetHttpStop()
+
+	fields := logrus.Fields{
+		"event_type":     msg.GetEventType().String(),
+		"origin":         msg.GetOrigin(),
+		"cf_app_id":      httpStop.GetApplicationId(),
+		"content_length": httpStop.GetContentLength(),
+		"peer_type":      httpStop.GetPeerType(),
+		"request_id":     httpStop.GetRequestId(),
+		"status_code":    httpStop.GetStatusCode(),
+		"timestamp":      httpStop.GetTimestamp(),
+		"uri":            httpStop.GetUri(),
+	}
+
+	return Event{
+		Fields: fields,
+		Msg:    "",
+	}
+}
+
+func HttpStartStop(msg *events.Envelope) Event {
+	httpStartStop := msg.GetHttpStartStop()
+
+	fields := logrus.Fields{
+		"event_type":        msg.GetEventType().String(),
+		"origin":            msg.GetOrigin(),
+		"cf_app_id":         httpStartStop.GetApplicationId(),
+		"content_length":    httpStartStop.GetContentLength(),
+		"instance_id":       httpStartStop.GetInstanceId(),
+		"instance_index":    httpStartStop.GetInstanceIndex(),
+		"method":            httpStartStop.GetMethod(),
+		"parent_request_id": httpStartStop.GetParentRequestId(),
+		"peer_type":         httpStartStop.GetPeerType(),
+		"remote_addr":       httpStartStop.GetRemoteAddress(),
+		"request_id":        httpStartStop.GetRequestId(),
+		"start_timestamp":   httpStartStop.GetStartTimestamp(),
+		"status_code":       httpStartStop.GetStatusCode(),
+		"stop_timestamp":    httpStartStop.GetStopTimestamp(),
+		"uri":               httpStartStop.GetUri(),
+		"user_agent":        httpStartStop.GetUserAgent(),
+	}
+
+	return Event{
+		Fields: fields,
+		Msg:    "",
+	}
+}
+
+func LogMessage(msg *events.Envelope) Event {
+	logMessage := msg.GetLogMessage()
+
+	fields := logrus.Fields{
+		"event_type":      msg.GetEventType().String(),
+		"origin":          msg.GetOrigin(),
+		"cf_app_id":       logMessage.GetAppId(),
+		"timestamp":       logMessage.GetTimestamp(),
+		"source_type":     logMessage.GetSourceType(),
+		"message_type":    logMessage.GetMessageType().String(),
+		"source_instance": logMessage.GetSourceInstance(),
+	}
+
+	return Event{
+		Fields: fields,
+		Msg:    string(logMessage.GetMessage()),
+	}
+}
+
+func ValueMetric(msg *events.Envelope) Event {
+	valMetric := msg.GetValueMetric()
+
+	fields := logrus.Fields{
+		"event_type": msg.GetEventType().String(),
+		"origin":     msg.GetOrigin(),
+		"name":       valMetric.GetName(),
+		"unit":       valMetric.GetUnit(),
+		"value":      valMetric.GetValue(),
+	}
+
+	return Event{
+		Fields: fields,
+		Msg:    "",
+	}
+}
+
+func CounterEvent(msg *events.Envelope) Event {
+	counterEvent := msg.GetCounterEvent()
+
+	fields := logrus.Fields{
+		"event_type": msg.GetEventType().String(),
+		"origin":     msg.GetOrigin(),
+		"name":       counterEvent.GetName(),
+		"delta":      counterEvent.GetDelta(),
+		"total":      counterEvent.GetTotal(),
+	}
+
+	return Event{
+		Fields: fields,
+		Msg:    "",
+	}
+}
+
+func ErrorEvent(msg *events.Envelope) Event {
+	errorEvent := msg.GetError()
+
+	fields := logrus.Fields{
+		"event_type": msg.GetEventType().String(),
+		"origin":     msg.GetOrigin(),
+		"code":       errorEvent.GetCode(),
+		"delta":      errorEvent.GetSource(),
+	}
+
+	return Event{
+		Fields: fields,
+		Msg:    errorEvent.GetMessage(),
+	}
+}
+
+func ContainerMetric(msg *events.Envelope) Event {
+	containerMetric := msg.GetContainerMetric()
+
+	fields := logrus.Fields{
+		"event_type":     msg.GetEventType().String(),
+		"origin":         msg.GetOrigin(),
+		"cf_app_id":      containerMetric.GetApplicationId(),
+		"cpu_percentage": containerMetric.GetCpuPercentage(),
+		"disk_bytes":     containerMetric.GetDiskBytes(),
+		"instance_index": containerMetric.GetInstanceIndex(),
+		"memory_bytes":   containerMetric.GetMemoryBytes(),
+	}
+
+	return Event{
+		Fields: fields,
+		Msg:    "",
+	}
+}
+
+func (e *Event) AnnotateWithAppData() {
+	cf_app_id := e.Fields["cf_app_id"]
+	if cf_app_id != nil && cf_app_id != "" {
+		appInfo := getAppInfo(fmt.Sprintf("%s", cf_app_id))
+		cf_app_name := appInfo.Name
+		cf_space_id := appInfo.SpaceGuid
+		cf_space_name := appInfo.SpaceName
+		cf_org_id := appInfo.OrgGuid
+		cf_org_name := appInfo.OrgName
+
+		if cf_app_name != "" {
+			e.Fields["cf_app_name"] = cf_app_name
+		}
+
+		if cf_space_id != "" {
+			e.Fields["cf_space_id"] = cf_space_id
+		}
+
+		if cf_space_name != "" {
+			e.Fields["cf_space_name"] = cf_space_name
+		}
+
+		if cf_org_id != "" {
+			e.Fields["cf_org_id"] = cf_org_id
+		}
+
+		if cf_org_name != "" {
+			e.Fields["cf_org_name"] = cf_org_name
+		}
+	}
+}
+
+func (e Event) Log() {
+	logrus.WithFields(e.Fields).Info(e.Msg)
 }

--- a/events/events_suite_test.go
+++ b/events/events_suite_test.go
@@ -1,7 +1,9 @@
 package events_test
 
 import (
+	"github.com/Sirupsen/logrus"
 	"github.com/cloudfoundry-community/firehose-to-syslog/events"
+	. "github.com/cloudfoundry/noaa/events"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"testing"
@@ -35,6 +37,75 @@ var _ = Describe("Events", func() {
 					"CounterEvent":  true,
 				}
 				Expect(events.GetSelectedEvents("bogus,HttpStartStop,bogus1,CounterEvent")).To(Equal(expected))
+			})
+		})
+	})
+
+	Describe("Constructing a Event from a LogMessage", func() {
+		var eventType Envelope_EventType = 5
+		var messageType LogMessage_MessageType = 1
+		var posixStart int64 = 1
+		origin := "yomomma__0"
+		sourceType := "Kehe"
+		logMsg := "Help, I'm a rock! Help, I'm a rock! Help, I'm a cop! Help, I'm a cop!"
+		sourceInstance := ">9000"
+		appID := "eea38ba5-53a5-4173-9617-b442d35ec2fd"
+
+		logMessage := LogMessage{
+			Message:        []byte(logMsg),
+			AppId:          &appID,
+			Timestamp:      &posixStart,
+			SourceType:     &sourceType,
+			MessageType:    &messageType,
+			SourceInstance: &sourceInstance,
+		}
+
+		envelope := &Envelope{
+			EventType:  &eventType,
+			Origin:     &origin,
+			LogMessage: &logMessage,
+		}
+
+		Context("given a envelope", func() {
+			It("should give us what we want", func() {
+				event := events.LogMessage(envelope)
+				Expect(event.Fields["event_type"]).To(Equal("LogMessage"))
+				Expect(event.Fields["origin"]).To(Equal(origin))
+				Expect(event.Fields["cf_app_id"]).To(Equal(appID))
+				Expect(event.Fields["timestamp"]).To(Equal(posixStart))
+				Expect(event.Fields["source_type"]).To(Equal(sourceType))
+				Expect(event.Fields["message_type"]).To(Equal("OUT"))
+				Expect(event.Fields["source_instance"]).To(Equal(sourceInstance))
+				Expect(event.Msg).To(Equal(logMsg))
+			})
+		})
+	})
+
+	Describe("AnnotateWithAppData", func() {
+		Context("called with Fields set to empty map", func() {
+			It("should do nothing", func() {
+				event := events.Event{}
+				wanted := events.Event{}
+				event.AnnotateWithAppData()
+				Expect(event).To(Equal(wanted))
+			})
+		})
+
+		Context("called with Fields set to logrus.Fields", func() {
+			It("should do nothing", func() {
+				event := events.Event{logrus.Fields{}, ""}
+				wanted := events.Event{logrus.Fields{}, ""}
+				event.AnnotateWithAppData()
+				Expect(event).To(Equal(wanted))
+			})
+		})
+
+		Context("called with empty cf_app_id", func() {
+			It("should do nothing", func() {
+				event := events.Event{logrus.Fields{"cf_app_id": ""}, ""}
+				wanted := events.Event{logrus.Fields{"cf_app_id": ""}, ""}
+				event.AnnotateWithAppData()
+				Expect(event).To(Equal(wanted))
 			})
 		})
 	})

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,201 +1,25 @@
 package logging
 
 import (
-	"fmt"
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/Sirupsen/logrus/hooks/syslog"
-	"github.com/cloudfoundry-community/firehose-to-syslog/caching"
-	"github.com/cloudfoundry/noaa/events"
 	"io/ioutil"
 	"log/syslog"
 	"os"
 )
 
 func SetupLogging(syslogServer string, debug bool) {
-	log.SetFormatter(&log.JSONFormatter{})
-	log.SetOutput(os.Stdout)
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetOutput(os.Stdout)
 	if !debug {
-		log.SetOutput(ioutil.Discard)
+		logrus.SetOutput(ioutil.Discard)
 	}
 	if syslogServer != "" {
 		hook, err := logrus_syslog.NewSyslogHook("tcp", syslogServer, syslog.LOG_INFO, "doppler")
 		if err != nil {
-			log.Error("Unable to connect to syslog server.")
+			logrus.Error("Unable to connect to syslog server.")
 		} else {
-			log.AddHook(hook)
+			logrus.AddHook(hook)
 		}
 	}
-}
-
-func getAppInfo(appGuid string) caching.App {
-	if app := caching.GetAppInfo(appGuid); app.Name != "" {
-		return app
-	} else {
-		caching.GetAppByGuid(appGuid)
-	}
-	return caching.GetAppInfo(appGuid)
-}
-
-func Heartbeats(msg *events.Envelope) {
-	heartbeat := msg.GetHeartbeat()
-
-	log.WithFields(log.Fields{
-		"ctl_msg_id":     heartbeat.GetControlMessageIdentifier(),
-		"error_count":    heartbeat.GetErrorCount(),
-		"event_type":     msg.GetEventType().String(),
-		"origin":         msg.GetOrigin(),
-		"received_count": heartbeat.GetReceivedCount(),
-		"sent_count":     heartbeat.GetSentCount(),
-	}).Info("")
-}
-
-func HttpStarts(msg *events.Envelope) {
-	httpStart := msg.GetHttpStart()
-	appInfo := getAppInfo(fmt.Sprintf("%s", httpStart.GetApplicationId()))
-
-	log.WithFields(log.Fields{
-		"event_type":        msg.GetEventType().String(),
-		"origin":            msg.GetOrigin(),
-		"cf_app_id":         httpStart.GetApplicationId(),
-		"cf_app_name":       appInfo.Name,
-		"cf_space_id":       appInfo.SpaceGuid,
-		"cf_space_name":     appInfo.SpaceName,
-		"cf_org_id":         appInfo.OrgGuid,
-		"cf_org_name":       appInfo.OrgName,
-		"instance_id":       httpStart.GetInstanceId(),
-		"instance_index":    httpStart.GetInstanceIndex(),
-		"method":            httpStart.GetMethod(),
-		"parent_request_id": httpStart.GetParentRequestId(),
-		"peer_type":         httpStart.GetPeerType(),
-		"request_id":        httpStart.GetRequestId(),
-		"remote_addr":       httpStart.GetRemoteAddress(),
-		"timestamp":         httpStart.GetTimestamp(),
-		"uri":               httpStart.GetUri(),
-		"user_agent":        httpStart.GetUserAgent(),
-	}).Info("")
-}
-
-func HttpStops(msg *events.Envelope) {
-	httpStop := msg.GetHttpStop()
-	appInfo := getAppInfo(fmt.Sprintf("%s", httpStop.GetApplicationId()))
-
-	log.WithFields(log.Fields{
-		"event_type":     msg.GetEventType().String(),
-		"origin":         msg.GetOrigin(),
-		"cf_app_id":      httpStop.GetApplicationId(),
-		"cf_app_name":    appInfo.Name,
-		"cf_space_id":    appInfo.SpaceGuid,
-		"cf_space_name":  appInfo.SpaceName,
-		"cf_org_id":      appInfo.OrgGuid,
-		"cf_org_name":    appInfo.OrgName,
-		"content_length": httpStop.GetContentLength(),
-		"peer_type":      httpStop.GetPeerType(),
-		"request_id":     httpStop.GetRequestId(),
-		"status_code":    httpStop.GetStatusCode(),
-		"timestamp":      httpStop.GetTimestamp(),
-		"uri":            httpStop.GetUri(),
-	}).Info("")
-}
-
-func HttpStartStops(msg *events.Envelope) {
-	httpStartStop := msg.GetHttpStartStop()
-	appInfo := getAppInfo(fmt.Sprintf("%s", httpStartStop.GetApplicationId()))
-
-	log.WithFields(log.Fields{
-		"event_type":        msg.GetEventType().String(),
-		"origin":            msg.GetOrigin(),
-		"cf_app_id":         httpStartStop.GetApplicationId(),
-		"cf_app_name":       appInfo.Name,
-		"cf_space_id":       appInfo.SpaceGuid,
-		"cf_space_name":     appInfo.SpaceName,
-		"cf_org_id":         appInfo.OrgGuid,
-		"cf_org_name":       appInfo.OrgName,
-		"content_length":    httpStartStop.GetContentLength(),
-		"instance_id":       httpStartStop.GetInstanceId(),
-		"instance_index":    httpStartStop.GetInstanceIndex(),
-		"method":            httpStartStop.GetMethod(),
-		"parent_request_id": httpStartStop.GetParentRequestId(),
-		"peer_type":         httpStartStop.GetPeerType(),
-		"remote_addr":       httpStartStop.GetRemoteAddress(),
-		"request_id":        httpStartStop.GetRequestId(),
-		"start_timestamp":   httpStartStop.GetStartTimestamp(),
-		"status_code":       httpStartStop.GetStatusCode(),
-		"stop_timestamp":    httpStartStop.GetStopTimestamp(),
-		"uri":               httpStartStop.GetUri(),
-		"user_agent":        httpStartStop.GetUserAgent(),
-	}).Info("")
-}
-
-func LogMessages(msg *events.Envelope) {
-	logMessage := msg.GetLogMessage()
-	appInfo := getAppInfo(fmt.Sprintf("%s", logMessage.GetAppId()))
-
-	log.WithFields(log.Fields{
-		"event_type":      msg.GetEventType().String(),
-		"origin":          msg.GetOrigin(),
-		"cf_app_id":       logMessage.GetAppId(),
-		"cf_app_name":     appInfo.Name,
-		"cf_space_id":     appInfo.SpaceGuid,
-		"cf_space_name":   appInfo.SpaceName,
-		"cf_org_id":       appInfo.OrgGuid,
-		"cf_org_name":     appInfo.OrgName,
-		"timestamp":       logMessage.GetTimestamp(),
-		"source_type":     logMessage.GetSourceType(),
-		"message_type":    logMessage.GetMessageType().String(),
-		"source_instance": logMessage.GetSourceInstance(),
-	}).Info(string(logMessage.GetMessage()))
-}
-
-func ValueMetrics(msg *events.Envelope) {
-	valMetric := msg.GetValueMetric()
-
-	log.WithFields(log.Fields{
-		"event_type": msg.GetEventType().String(),
-		"origin":     msg.GetOrigin(),
-		"name":       valMetric.GetName(),
-		"unit":       valMetric.GetUnit(),
-		"value":      valMetric.GetValue(),
-	}).Info("")
-}
-
-func CounterEvents(msg *events.Envelope) {
-	counterEvent := msg.GetCounterEvent()
-
-	log.WithFields(log.Fields{
-		"event_type": msg.GetEventType().String(),
-		"origin":     msg.GetOrigin(),
-		"name":       counterEvent.GetName(),
-		"delta":      counterEvent.GetDelta(),
-		"total":      counterEvent.GetTotal(),
-	}).Info("")
-}
-
-func ErrorEvents(msg *events.Envelope) {
-	errorEvent := msg.GetError()
-
-	log.WithFields(log.Fields{
-		"event_type": msg.GetEventType().String(),
-		"origin":     msg.GetOrigin(),
-		"code":       errorEvent.GetCode(),
-		"delta":      errorEvent.GetSource(),
-	}).Info(errorEvent.GetMessage())
-}
-
-func ContainerMetrics(msg *events.Envelope) {
-	containerMetric := msg.GetContainerMetric()
-	appInfo := getAppInfo(fmt.Sprintf("%s", containerMetric.GetApplicationId()))
-	log.WithFields(log.Fields{
-		"event_type":     msg.GetEventType().String(),
-		"origin":         msg.GetOrigin(),
-		"cf_app_id":      containerMetric.GetApplicationId(),
-		"cf_app_name":    appInfo.Name,
-		"cf_space_id":    appInfo.SpaceGuid,
-		"cf_space_name":  appInfo.SpaceName,
-		"cf_org_id":      appInfo.OrgGuid,
-		"cf_org_name":    appInfo.OrgName,
-		"cpu_percentage": containerMetric.GetCpuPercentage(),
-		"disk_bytes":     containerMetric.GetDiskBytes(),
-		"instance_index": containerMetric.GetInstanceIndex(),
-		"memory_bytes":   containerMetric.GetMemoryBytes(),
-	}).Info("")
 }

--- a/main.go
+++ b/main.go
@@ -75,8 +75,7 @@ func main() {
 	token := cfClient.GetToken()
 	firehose := firehose.CreateFirehoseChan(dopplerEndpoint, token, *subscriptionId, *skipSSLValidation)
 
-	logging.SetupLogging(*syslogServer, *debug)
-
 	selectedEvents := events.GetSelectedEvents(*wantedEvents)
+	logging.SetupLogging(*syslogServer, *debug)
 	events.RouteEvents(firehose, selectedEvents)
 }


### PR DESCRIPTION
Want to run this trough you guys/gals out there. As pointed out by https://github.com/cloudfoundry-community/firehose-to-syslog/issues/17 we want more tests!

Instead of logging in each of the functions, create a struct instead. Then call AnnotateWithAppData() on the struct, then simply call .Log() on it.

This is a start to break out any external calls as much as possible from the logic to allow easier testing.

This also kinda addresses @mrdavidlaing comment over at https://github.com/cloudfoundry-community/firehose-to-syslog/issues/6

What do you think?