### PR TITLE
Some stability and logging updates as well as a new feature to get container metrics during cache refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 firehose-to-syslog*
+events/events.test
+.project
+*.swp
 .#*
 \#*
 my.db

--- a/caching/caching.go
+++ b/caching/caching.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"encoding/json"
+	log "github.com/cloudfoundry-community/firehose-to-syslog/logging"
 	"fmt"
 	"github.com/boltdb/bolt"
 	cfClient "github.com/cloudfoundry-community/go-cfclient"
@@ -67,18 +68,40 @@ func GetAppByGuid(appGuid string) []App {
 }
 
 func GetAllApp() []App {
+
+	log.LogStd("Retrieving Apps for Cache...", false)
 	var apps []App
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.LogError("Recovered in caching.GetAllApp()", r)
+		}
+	}()
+
 	for _, app := range gcfClient.ListApps() {
+		log.LogStd(fmt.Sprintf("App [%s] Found...\n", app.Name), false)
 		apps = append(apps, App{app.Name, app.Guid, app.SpaceData.Entity.Name, app.SpaceData.Entity.Guid, app.SpaceData.Entity.OrgData.Entity.Name, app.SpaceData.Entity.OrgData.Entity.Guid})
 	}
+
 	FillDatabase(apps)
+
+	log.LogStd(fmt.Sprintf("Found [%d] Apps!", len(apps)), false)
+
 	return apps
 }
 
 func GetAppInfo(appGuid string) App {
+
+	defer func() {
+		if r := recover(); r != nil {
+			log.LogError(fmt.Sprintf("Recovered from panic retrieving App Info for App Guid: %s", appGuid), r)
+		}
+	}()
+
 	var d []byte
 	var app App
 	appdb.View(func(tx *bolt.Tx) error {
+		log.LogStd(fmt.Sprintf("Looking for App %s in Cache!\n", appGuid), false)
 		b := tx.Bucket([]byte("AppBucket"))
 		d = b.Get([]byte(appGuid))
 		return nil

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,25 +1,75 @@
 package logging
 
 import (
+	"fmt"
 	"github.com/Sirupsen/logrus"
 	"github.com/Sirupsen/logrus/hooks/syslog"
 	"io/ioutil"
 	"log/syslog"
 	"os"
+	"time"
 )
 
-func SetupLogging(syslogServer string, debug bool) {
+var (
+	debugFlag bool
+	syslogServer string	
+)
+
+func Connect() bool {
+
+	success := false
+
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	logrus.SetOutput(os.Stdout)
-	if !debug {
+
+	if !debugFlag {
 		logrus.SetOutput(ioutil.Discard)
+	} else {
+		logrus.SetOutput(os.Stdout)
 	}
 	if syslogServer != "" {
 		hook, err := logrus_syslog.NewSyslogHook("tcp", syslogServer, syslog.LOG_INFO, "doppler")
 		if err != nil {
-			logrus.Error("Unable to connect to syslog server.")
+			LogError(fmt.Sprintf("Unable to connect to syslog server [%s]!\n", syslogServer),err.Error())
 		} else {
+			LogStd(fmt.Sprintf("Received hook to syslog server [%s]!\n", syslogServer), false)
 			logrus.AddHook(hook)
+			
+			success = true;
 		}
+	}	
+	
+	return success
+}
+
+
+func SetupLogging(syslogSvr string, debug bool) {
+	debugFlag = debug
+	syslogServer = syslogSvr
+}
+
+func LogStd(message string, force bool) {
+	Log(message, force, false, nil)
+}
+
+func LogError(message string, errMsg interface{}) {
+
+	Log(message, false, true, errMsg)
+}
+
+func Log(message string, force bool, isError bool, err interface{}) {
+
+	if debugFlag || force || isError {
+
+		writer := os.Stdout
+		var formattedMessage string
+
+		if isError {
+			writer = os.Stderr
+			formattedMessage = fmt.Sprintf("[%s] Exception occurred! Message: %s Details: %v", time.Now().String(), message, err)
+		} else {
+			formattedMessage = fmt.Sprintf("[%s] %s", time.Now().String(), message)
+		}
+
+		fmt.Fprintln(writer, formattedMessage)
 	}
 }


### PR DESCRIPTION
Hi,

First, let me say thanks! Firehose-to-syslog is a cool tool. Second, let me say this is my first time writing go and Im hoping I didn't stray to far from accepted practice. So, whatever feedback you can offer me in that area would be greatly appreciated. Ok, to get to the point...I have been experiencing some stability issues with firehose-to-syslog in my environment. While they may only be related to my CF deployment it seemed like a few things in the tool would make it more robust. In order to help me determine what exactly was going on I also modified/adding logging in places. I also added a new cmd line argument and feature to pull container metrics during app caching. 

The issues/changes are:

* for stability I added deferred recover calls in several places throughout the app. Hopefully this isn't bad form.

* firehose-to-syslog would start up and throw an EOF on the firehose chan(no explanation) after about 10 minutes. Once this occurs once or twice (the executable doesn’t abend) I would stop getting logs in Logstash. It will throw 5 of those EOFs before failing completely. (Note: the subscription/connection being made with the NOAA client has 5 retries built-in.)

* As my uaa token would expire it would seem to auto-refresh a few times but eventually I would get a not-authorized error and the executable would abend.

* The caching function seemed to cause panics and abend the app intermittantly. I finally tracked this down to an App Guid that would come through not as a UUID or nil but as a string "\<nil\>". I modified that logic a little in the AnnotateWithAppData func in events to solve this. Once again, this may be something that was caused by my environment but it can't hurt to add the extra check. _Note: this is our lab environment and we currently only have one app deployed there._

* As I stated above I was never seeing any ‘Container Metric Events’ come out of the firehose. After some investigation I found a separate function that returned them in the NOAA client. I don’t know if that is the only way to get them or not…that function requires an app guid to make the connection/subscription. So, I added a new feature to pull for them by APP GUID during the cache refresh. This feature is switched and can be activated with the cmd line argument --include-container-metrics. We only have one app and it isn’t generating any of these events. I thought it would be something baked into the CF framework as the metrics in question are CPU, MEM, Disk Utilization…but even now that I am attempting to pull them I don’t get any. I will have to investigate back into the core CF code to determine what’s up with that. It may be its WIP (work in progress) or it could be (most likely :)) I am doing something wrong…To support this change I had to refactor the events.go a little to be able to re-utilize the route events func logic. I also renamed the Log func in events to ShipEvent().

I also updated the existing tests to ensure they all still ran after my changes.

Please advise if I can provide any more detail and sorry for the big change set and long story.

Cheers,

Jon
Senior Consultant
ECSTeam Inc. 