### PR TITLE
Add optional --doppler-port flag to enable setting a custom doppler port

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Flags:
   --help              Show help.
   --debug             Enable debug mode. This disables forwarding to syslog
   --domain="10.244.0.34.xip.io" Domain of your CF installation.
+  --doppler-port=443  Port used by doppler/loggregator in your CF installation.
   --syslog-server=SYSLOG-SERVER
                       Syslog server.
   --subscription-id=firehose  Id for the subscription.

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 var (
 	debug             = kingpin.Flag("debug", "Enable debug mode. This disables forwarding to syslog").Bool()
 	domain            = kingpin.Flag("domain", "Domain of your CF installation.").Default("10.244.0.34.xip.io").String()
+	dopplerPort       = kingpin.Flag("doppler-port", "Custom port for doppler / loggregator endpoint").Default("443").Int()
 	syslogServer      = kingpin.Flag("syslog-server", "Syslog server.").String()
 	subscriptionId    = kingpin.Flag("subscription-id", "Id for the subscription.").Default("firehose").String()
 	user              = kingpin.Flag("user", "Admin user.").Default("admin").String()
@@ -33,7 +34,7 @@ func main() {
 
 	apiEndpoint := fmt.Sprintf("https://api.%s", *domain)
 	uaaEndpoint := fmt.Sprintf("https://uaa.%s", *domain)
-	dopplerEndpoint := fmt.Sprintf("wss://doppler.%s", *domain)
+	dopplerEndpoint := fmt.Sprintf("wss://doppler.%s:%d", *domain, *dopplerPort)
 
 	c := cfclient.Config{
 		ApiAddress:        apiEndpoint,


### PR DESCRIPTION
When running CF behind AWS ELBs; you need to use a custom Loggregator/Doppler port due to ELB restrictions ([discussion](http://support.run.pivotal.io/entries/80621715-Does-cloudfoundry-allows-the-websocket-requests-on-port-other-than-4443-)

Currently the firehose-to-syslog assumes that the doppler endpoint will be on the default `wss` port 443 and throws the error below when attempting to connect to a doppler endpoint running on a different port:

```
Error dialing traffic controller server: websocket: bad handshake.
Please ask your Cloud Foundry Operator to check the platform configuration (traffic controller is wss://doppler.system.cf-example.com)
```

This pull request adds an additional (optional) flag that defaults to `443` to maintain existing behaviour, but allows the doppler port to be overridden.