### PR TITLE
Feature/use info enpoint v2

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-community/go-cfclient",
-			"Rev": "b2e431669f61a5f16b27624daa1bba36fd994d6f"
+			"Rev": "6403c93717cd39916b1c7b084a1d7d7847c476b4"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry/noaa",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,7 +22,7 @@
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry-community/go-cfclient",
-			"Rev": "6403c93717cd39916b1c7b084a1d7d7847c476b4"
+			"Rev": "6eec4c0c300b7f6eab09b91adc97a6bba8f64233"
 		},
 		{
 			"ImportPath": "github.com/cloudfoundry/noaa",

--- a/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/LICENSE
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2015 Long Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/cf_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/cf_test.go
@@ -29,6 +29,7 @@ func setupMultiple(mockEndpoints []MockRoute) {
 	server = httptest.NewServer(mux)
 	fakeUAAServer = FakeUAAServer()
 	m := martini.New()
+	m.Use(render.Renderer())
 	r := martini.NewRouter()
 	for _, mock := range mockEndpoints {
 		method := mock.Method
@@ -44,6 +45,14 @@ func setupMultiple(mockEndpoints []MockRoute) {
 			})
 		}
 	}
+	r.Get("/v2/info", func(r render.Render) {
+		r.JSON(200, map[string]interface{}{
+			"authorization_endpoint": fakeUAAServer.URL,
+			"token_endpoint":         fakeUAAServer.URL,
+			"logging_endpoint":       server.URL,
+		})
+
+	})
 
 	m.Action(r.Handle)
 	mux.Handle("/", m)

--- a/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/client.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/client.go
@@ -177,7 +177,6 @@ func (c *Client) doRequest(r *request) (*http.Response, error) {
 		return nil, err
 	}
 	resp, err := c.config.HttpClient.Do(req)
-	defer resp.Body.Close()
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/client.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/client.go
@@ -10,11 +10,19 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 )
 
 //Client used to communicate with Cloud Foundry
 type Client struct {
-	config Config
+	config   Config
+	Endpoint Endpoint
+}
+
+type Endpoint struct {
+	DopplerAddress string `json:"logging_endpoint"`
+	TokenEndpoint  string `json:"authorization_endpoint"`
+	AuthEndpoint   string `json:"token_endpoint"`
 }
 
 //Config is used to configure the creation of a client
@@ -39,6 +47,8 @@ type request struct {
 }
 
 //DefaultConfig configuration for client
+//Keep LoginAdress for backward compatibility
+//Need to be remove in close future
 func DefaultConfig() *Config {
 	return &Config{
 		ApiAddress:        "https://api.10.244.0.34.xip.io",
@@ -48,6 +58,14 @@ func DefaultConfig() *Config {
 		Token:             "",
 		SkipSslValidation: false,
 		HttpClient:        http.DefaultClient,
+	}
+}
+
+func DefaultEndpoint() *Endpoint {
+	return &Endpoint{
+		DopplerAddress: "wss://loggregator.10.244.0.34.xip.io:443",
+		TokenEndpoint:  "https://uaa.10.244.0.34.xip.io",
+		AuthEndpoint:   "https://login.10.244.0.34.xip.io",
 	}
 }
 
@@ -77,7 +95,6 @@ func NewClient(config *Config) *Client {
 	}
 
 	ctx := oauth2.NoContext
-
 	if config.SkipSslValidation == false {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, defConfig.HttpClient)
 	} else {
@@ -90,12 +107,20 @@ func NewClient(config *Config) *Client {
 
 	}
 
+	endpoint, err := getInfo(config.ApiAddress, oauth2.NewClient(ctx, nil))
+
+	if err != nil {
+		log.Println("Could not get api /v2/info :", err)
+		os.Exit(1)
+
+	}
+
 	authConfig := &oauth2.Config{
 		ClientID: "cf",
 		Scopes:   []string{""},
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  config.LoginAddress + "/oauth/auth",
-			TokenURL: config.LoginAddress + "/oauth/token",
+			AuthURL:  endpoint.AuthEndpoint + "/oauth/auth",
+			TokenURL: endpoint.TokenEndpoint + "/oauth/token",
 		},
 	}
 
@@ -109,9 +134,30 @@ func NewClient(config *Config) *Client {
 	config.TokenSource = authConfig.TokenSource(ctx, token)
 
 	client := &Client{
-		config: *config,
+		config:   *config,
+		Endpoint: *endpoint,
 	}
 	return client
+}
+func getInfo(api string, httpClient *http.Client) (*Endpoint, error) {
+	var endpoint Endpoint
+
+	if api == "" {
+		return DefaultEndpoint(), nil
+	}
+
+	resp, err := httpClient.Get(api + "/v2/info")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = decodeBody(resp, &endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &endpoint, err
 }
 
 // newRequest is used to create a new request
@@ -131,6 +177,7 @@ func (c *Client) doRequest(r *request) (*http.Response, error) {
 		return nil, err
 	}
 	resp, err := c.config.HttpClient.Do(req)
+	defer resp.Body.Close()
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/client_test.go
+++ b/Godeps/_workspace/src/github.com/cloudfoundry-community/go-cfclient/client_test.go
@@ -18,19 +18,6 @@ func TestDefaultConfig(t *testing.T) {
 	})
 }
 
-func TestCreateNewClient(t *testing.T) {
-	Convey("Create new client", t, func() {
-		c := &Config{
-			ApiAddress:   "",
-			LoginAddress: "",
-			Username:     "",
-			Password:     "",
-		}
-		client := NewClient(c)
-		So(client, ShouldNotBeNil)
-	})
-}
-
 func TestMakeRequest(t *testing.T) {
 	Convey("Test making request", t, func() {
 		setup(MockRoute{"GET", "/v2/organizations", listOrgsPayload})

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
+# Firehose-to-syslog
+
 This nifty util aggregates all the events from the firehose feature in
 CloudFoundry.
 
-	./firehose-to-logstash \
-		--domain=cf.installation.domain.com \
+	./firehose-to-syslog \
+		--api-address="https://api.10.244.0.34.xip.io" \
 		--user=admin-username \
 		--password=admin-password \
 		--debug
 
-	{"cf_app_id":"e626413b-f1f8-436d-8963-c46f7cb345eb","cf_app_name":"php-diego-one","cf_org_id":"ebd95a83-5b6a-43ff-af67-a234ece3fb78","cf_org_name":"GWENN","cf_space_id":"a2e4c75b-fe02-4078-abfb-87539352aeac","cf_space_name":"GWENN-SPACE","cpu_percentage":1.4523587130944957,"disk_bytes":0,"event_type":"ContainerMetric","instance_index":0,"level":"info","memory_bytes":14110720,"msg":"","origin":"executor","time":"2015-04-17T13:59:52-07:00"}
+	{"cf_app_id":"c5cb762b-b7bb-44b6-97d1-2b612d4baba9","cf_app_name":"lattice","cf_org_id":"fb5777e6-e234-4832-8844-773114b505b0","cf_org_name":"GWENN","cf_origin":"firehose","cf_space_id":"3c910823-22e7-41ff-98de-094759594398","cf_space_name":"GWENN-SPACE","event_type":"LogMessage","level":"info","message_type":"OUT","msg":"Lattice-app. Says Hello. on index: 0","origin":"rep","source_instance":"0","source_type":"APP","time":"2015-06-12T11:46:11+09:00","timestamp":1434077171244715915}
 
 # Options
 
@@ -15,20 +17,35 @@ CloudFoundry.
 usage: firehose-to-syslog [<flags>]
 
 Flags:
-  --help              Show help.
+  --help              Show help (also see --help-long and --help-man).
   --debug             Enable debug mode. This disables forwarding to syslog
-  --domain="10.244.0.34.xip.io" Domain of your CF installation.
+  --api-address="https://api.10.244.0.34.xip.io"
+                      Api endpoint address.
+  --doppler-address=DOPPLER-ADDRESS
+                      Overwrite default doppler endpoint return by /v2/info
   --syslog-server=SYSLOG-SERVER
                       Syslog server.
-  --subscription-id=firehose  Id for the subscription.
-  --user=admin      Admin user.
-  --password=admin  Admin password.
-  --skip-ssl-validation Please don\'t
-  --events=LogMessage Comma seperated list of events you would like. Valid options are HttpStart, HttpStop, Heartbeat, HttpStartStop, LogMessage, ValueMetric, CounterEvent, Error, ContainerMetric
-  --boltdb-path='my.db' Bolt Database path
+  --subscription-id="firehose"
+                      Id for the subscription.
+  --user="admin"      Admin user.
+  --password="admin"  Admin password.
+  --skip-ssl-validation
+                      Please don't
+  --events="LogMessage"
+                      Comma seperated list of events you would like. Valid options are Heartbeat, HttpStop, LogMessage, Error, HttpStart,
+                      HttpStartStop, ValueMetric, CounterEvent, ContainerMetric
+  --boltdb-path="my.db"
+                      Bolt Database path
   --cc-pull-time=60s  CloudController Pooling time in sec
   --version           Show application version.
 ```
+
+#Endpoint definition
+
+We use [gocf-client](https://github.com/cloudfoundry-community/go-cfclient) which will call the CF endpoint /v2/info to get Auth., doppler endpoint.
+
+But for doppler endpoint you can overwrite it with ``` --doppler-address ``` as we know some people use different endpoint.
+
 # Event documentation
 
 See the [dropsonde protocol documentation](https://github.com/cloudfoundry/dropsonde-protocol/tree/master/events) for details on what data is sent as part of each event.

--- a/main.go
+++ b/main.go
@@ -16,7 +16,8 @@ import (
 
 var (
 	debug             = kingpin.Flag("debug", "Enable debug mode. This disables forwarding to syslog").Default("false").Bool()
-	domain            = kingpin.Flag("domain", "Domain of your CF installation.").Default("10.244.0.34.xip.io").String()
+	apiEndpoint       = kingpin.Flag("api-address", "Api endpoint address.").Default("https://api.10.244.0.34.xip.io").String()
+	dopplerAddress     = kingpin.Flag("doppler-address", "Overwrite default doppler endpoint return by /v2/info").String()
 	syslogServer      = kingpin.Flag("syslog-server", "Syslog server.").String()
 	subscriptionId    = kingpin.Flag("subscription-id", "Id for the subscription.").Default("firehose").String()
 	user              = kingpin.Flag("user", "Admin user.").Default("admin").String()
@@ -31,20 +32,20 @@ func main() {
 	kingpin.Version("0.1.0 - f3d31bd")
 	kingpin.Parse()
 
-	apiEndpoint := fmt.Sprintf("https://api.%s", *domain)
-	uaaEndpoint := fmt.Sprintf("https://uaa.%s", *domain)
-	dopplerEndpoint := fmt.Sprintf("wss://doppler.%s", *domain)
 
 	logging.SetupLogging(*syslogServer, *debug)
 
 	c := cfclient.Config{
 		ApiAddress:        apiEndpoint,
-		LoginAddress:      uaaEndpoint,
+		LoginAddress:      "",
 		Username:          *user,
 		Password:          *password,
 		SkipSslValidation: *skipSSLValidation,
 	}
 	cfClient := cfclient.NewClient(&c)
+
+
+	dopplerEndpoint := 
 
 	//Use bolt for in-memory  - file caching
 	db, err := bolt.Open(*boltDatabasePath, 0600, &bolt.Options{Timeout: 1 * time.Second})

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 var (
 	debug             = kingpin.Flag("debug", "Enable debug mode. This disables forwarding to syslog").Default("false").Bool()
 	apiEndpoint       = kingpin.Flag("api-address", "Api endpoint address.").Default("https://api.10.244.0.34.xip.io").String()
-	dopplerAddress     = kingpin.Flag("doppler-address", "Overwrite default doppler endpoint return by /v2/info").String()
+	dopplerAddress    = kingpin.Flag("doppler-address", "Overwrite default doppler endpoint return by /v2/info").String()
 	syslogServer      = kingpin.Flag("syslog-server", "Syslog server.").String()
 	subscriptionId    = kingpin.Flag("subscription-id", "Id for the subscription.").Default("firehose").String()
 	user              = kingpin.Flag("user", "Admin user.").Default("admin").String()
@@ -28,24 +28,30 @@ var (
 	tickerTime        = kingpin.Flag("cc-pull-time", "CloudController Pooling time in sec").Default("60s").Duration()
 )
 
-func main() {
-	kingpin.Version("0.1.0 - f3d31bd")
-	kingpin.Parse()
+const (
+	version = "0.1.0 - f3d31bd"
+)
 
+func main() {
+	kingpin.Version(version)
+	kingpin.Parse()
+	logging.LogStd(fmt.Sprintf("Starting firehose-to-syslog %s ", version), true)
 
 	logging.SetupLogging(*syslogServer, *debug)
 
 	c := cfclient.Config{
-		ApiAddress:        apiEndpoint,
-		LoginAddress:      "",
+		ApiAddress:        *apiEndpoint,
 		Username:          *user,
 		Password:          *password,
 		SkipSslValidation: *skipSSLValidation,
 	}
 	cfClient := cfclient.NewClient(&c)
 
-
-	dopplerEndpoint := 
+	dopplerEndpoint := cfClient.Endpoint.DopplerAddress
+	if len(*dopplerAddress) > 0 {
+		dopplerEndpoint = *dopplerAddress
+	}
+	logging.LogStd(fmt.Sprintf("Using %s as doppler endpoint", dopplerEndpoint), true)
 
 	//Use bolt for in-memory  - file caching
 	db, err := bolt.Open(*boltDatabasePath, 0600, &bolt.Options{Timeout: 1 * time.Second})


### PR DESCRIPTION
Hi,

This PR is pretty big,

I remove the domain option and add ```--api-address``` instead, because is more flexible, for example if some people use another endpoint that api, or another port etc...

So now we got the auth endpoint for the CC api and the loggregator/doppler too but this endpoint can be customize so with the flag ``` --doppler-address ``` you can overwrite it.

I added some debug output.

As go-cflient [PR](https://github.com/cloudfoundry-community/go-cfclient/pull/12) is still unmerge you have to use ``` godep go build ``` to build the exec or ``` make ... ```



