### PR TITLE
Annotate app logs with User-Provided environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Flags:
   --version           Show application version.
   --mode-prof         Enable profiling mode, one of [cpu, mem, block]
   --path-prof         Set the Path to write Profiling file
+  --app-env-vars      Annotate app logs with specific User-Provided environment variables.
 ```
 
 #Endpoint definition

--- a/events/events.go
+++ b/events/events.go
@@ -296,6 +296,7 @@ func (e *Event) AnnotateWithAppData() {
 		cf_space_name := appInfo.SpaceName
 		cf_org_id := appInfo.OrgGuid
 		cf_org_name := appInfo.OrgName
+		cf_app_env_vars := appInfo.EnvVars
 
 		if cf_app_name != "" {
 			e.Fields["cf_app_name"] = cf_app_name
@@ -316,6 +317,8 @@ func (e *Event) AnnotateWithAppData() {
 		if cf_org_name != "" {
 			e.Fields["cf_org_name"] = cf_org_name
 		}
+
+		e.Fields["cf_app_env_vars"] = cf_app_env_vars
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	boltDatabasePath   = kingpin.Flag("boltdb-path", "Bolt Database path ").Default("my.db").OverrideDefaultFromEnvar("BOLTDB_PATH").String()
 	tickerTime         = kingpin.Flag("cc-pull-time", "CloudController Polling time in sec").Default("60s").OverrideDefaultFromEnvar("CF_PULL_TIME").Duration()
 	extraFields        = kingpin.Flag("extra-fields", "Extra fields you want to annotate your events with, example: '--extra-fields=env:dev,something:other ").Default("").OverrideDefaultFromEnvar("EXTRA_FIELDS").String()
+	appEnvVars         = kingpin.Flag("app-env-vars", "Annotate app logs with specific User-Provided environment variables, example: '--app-env-vars=realm,team ").Default("").OverrideDefaultFromEnvar("APP_ENV_VARS").String()
 	modeProf           = kingpin.Flag("mode-prof", "Enable profiling mode, one of [cpu, mem, block]").Default("").OverrideDefaultFromEnvar("MODE_PROF").String()
 	pathProf           = kingpin.Flag("path-prof", "Set the Path to write profiling file").Default("").OverrideDefaultFromEnvar("PATH_PROF").String()
 )
@@ -92,6 +93,7 @@ func main() {
 	caching.SetCfClient(cfClient)
 	caching.SetAppDb(db)
 	caching.CreateBucket()
+	caching.SetupAppEnvVars(*appEnvVars)
 
 	//Let's Update the database the first time
 	logging.LogStd("Start filling app/space/org cache.", true)


### PR DESCRIPTION
We recently needed to annotate our apps with User-Provided environment variables from applications. For example, we wanted to group applications inside CF by department, all applications deployed by the *iot* team would provide an environment variable called *team*.

When I first seen the *extra-fields* feature I got exited and thought it was what I needed. Unfortunately it was just hard-codes values and not dynamically pulling the values from applications. 

This feature will pull environment variables from applications and inject them into the log message. 

I'm not sure if any other team will find this useful, but I thought I'd let the community make that decision. 

```
firehose-to-syslog --app-env-vars=team,realm ...
{"cf_app_env_vars":{"team":"iot","realm":"abc123"},"cf_app_id":"2do03b33...
```

*Note: This is my first time playing with Go*
Thanks