### PR TITLE
Disable CGO for cross compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ test:
 	ginkgo -r -v .
 
 linux32:
-	GOARCH=386 GOOS=linux go build --ldflags="-X main.version=${BUILD_NUMBER}" -o dist/linux/386/firehose-to-syslog_linux_386
+	 CGO_ENABLED=0 GOARCH=386 GOOS=linux go build --ldflags="-X main.version=${BUILD_NUMBER}" -o dist/linux/386/firehose-to-syslog_linux_386
 
 linux64:
-	GOARCH=amd64 GOOS=linux go build --ldflags="-X main.version=${BUILD_NUMBER}" -o dist/linux/amd64/firehose-to-syslog_linux_amd64
+	 CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build --ldflags="-X main.version=${BUILD_NUMBER}" -o dist/linux/amd64/firehose-to-syslog_linux_amd64
 
 darwin64:
 	GOARCH=amd64 GOOS=darwin go build --ldflags="-X main.version=${BUILD_NUMBER}" -o dist/darwin/amd64/firehose-to-syslog_darwin_amd64


### PR DESCRIPTION
Disable CGO for cross compile agains libc / muslc based distrib.

Should fix https://github.com/cloudfoundry-community/firehose-to-syslog/issues/105