### PR TITLE
Add ability to merge stack traces into a single event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ my.db
 start-firehose.sh
 dist
 *pprof
+.vscode
+debug

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Flags:
   --path-prof=""                 Set the Path to write profiling file
   --log-formatter-type=LOG-FORMATTER-TYPE
                                  Log formatter type to use. Valid options are text, json. If none provided, defaults to json.
+  --merge-stacktraces            Detect multi-line Java stack trace events and merge them into a single event.
   --version                      Show application version.
 ```
 

--- a/caching/caching.go
+++ b/caching/caching.go
@@ -23,6 +23,9 @@ type Caching interface {
 	GetAllApp() []App
 	GetAppInfo(string) App
 	GetAppInfoCache(string) App
+	PutMultiLineMessage(string, string, []byte)
+	GetMultiLineMessage(string, string) []byte
+	DeleteMultiLineMessage(string, string)
 	Close()
 }
 

--- a/caching/caching_emtpy.go
+++ b/caching/caching_emtpy.go
@@ -33,3 +33,13 @@ func (c *CachingEmpty) Close() {}
 func (c *CachingEmpty) GetAppInfoCache(appGuid string) App {
 	return App{}
 }
+
+func (c *CachingEmpty) PutMultiLineMessage(appGuid string, index string, msg []byte) {
+}
+
+func (c *CachingEmpty) GetMultiLineMessage(appGuid string, index string) []byte {
+	return make([]byte, 0)
+}
+
+func (c *CachingEmpty) DeleteMultiLineMessage(appGuid string, index string) {
+}

--- a/eventRouting/eventrouting.go
+++ b/eventRouting/eventrouting.go
@@ -20,16 +20,18 @@ type EventRouting struct {
 	CachingClient       caching.Caching
 	selectedEvents      map[string]bool
 	selectedEventsCount map[string]uint64
+	mergeStackTraces    bool
 	mutex               *sync.Mutex
 	log                 logging.Logging
 	ExtraFields         map[string]string
 }
 
-func NewEventRouting(caching caching.Caching, logging logging.Logging) *EventRouting {
+func NewEventRouting(caching caching.Caching, logging logging.Logging, mergeStackTraces bool) *EventRouting {
 	return &EventRouting{
 		CachingClient:       caching,
 		selectedEvents:      make(map[string]bool),
 		selectedEventsCount: make(map[string]uint64),
+		mergeStackTraces:    mergeStackTraces,
 		log:                 logging,
 		mutex:               &sync.Mutex{},
 		ExtraFields:         make(map[string]string),
@@ -75,7 +77,7 @@ func (e *EventRouting) RouteEvent(msg *events.Envelope) {
 		}
 
 		e.mutex.Lock()
-		if !(hasAppId && event.CachePartialEventMessage(e.CachingClient, e.log)) {
+		if !(e.mergeStackTraces && hasAppId && event.CachePartialEventMessage(e.CachingClient, e.log)) {
 			e.log.ShipEvents(event.Fields, event.Msg)
 			e.selectedEventsCount[eventType.String()]++
 		}

--- a/events/events.go
+++ b/events/events.go
@@ -1,17 +1,46 @@
 package events
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
+	"regexp"
+	"sort"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/cloudfoundry-community/firehose-to-syslog/caching"
+	"github.com/cloudfoundry-community/firehose-to-syslog/logging"
 	"github.com/cloudfoundry-community/firehose-to-syslog/utils"
 	"github.com/cloudfoundry/sonde-go/events"
 )
+
+type MsgLine struct {
+	Timestamp int64
+	Msg       string
+}
+type MsgLines []MsgLine
+
+func (slice MsgLines) Len() int {
+	return len(slice)
+}
+
+func (slice MsgLines) Less(i, j int) bool {
+	return slice[i].Timestamp < slice[j].Timestamp
+}
+
+func (slice MsgLines) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}
 
 type Event struct {
 	Fields map[string]interface{}
 	Msg    string
 	Type   string
+}
+
+type MultiLineMessage struct {
+	Event
+	MsgLines MsgLines
 }
 
 func HttpStart(msg *events.Envelope) *Event {
@@ -212,5 +241,112 @@ func (e *Event) AnnotateWithEnveloppeData(msg *events.Envelope) {
 	e.Fields["job"] = msg.GetJob()
 	e.Fields["index"] = msg.GetIndex()
 	e.Type = msg.GetEventType().String()
+}
 
+func (e *Event) CachePartialEventMessage(caching caching.Caching, log logging.Logging) bool {
+
+	var err error
+	var msg *MultiLineMessage
+
+	cfAppID := e.Fields["cf_app_id"]
+	cfAppIndex := e.Fields["index"]
+	timestamp := e.Fields["timestamp"].(int64)
+
+	isStackTraceStart, err := regexp.MatchString("^([a-z]\\w+\\.)+([a-zA-Z]\\w+Exception:).*", e.Msg)
+	if err != nil {
+		logging.LogError("Error checking if log message is a multi-line stacktrace!\n", err)
+		return false
+	}
+
+	isStackTraceMiddle, err := regexp.MatchString("^\\tat ([a-z]\\w+\\.)+([a-zA-Z][\\$_0-9a-zA-Z]+)\\.([a-z]\\w+)\\(.*\\)", e.Msg)
+	if err != nil {
+		logging.LogError("Error checking if log message is a multi-line stacktrace!\n", err)
+		return false
+	}
+
+	msgBytes := caching.GetMultiLineMessage(cfAppID.(string), cfAppIndex.(string))
+	if len(msgBytes) > 0 {
+		msg = &MultiLineMessage{}
+		cachedBuffer := bytes.NewBuffer(msgBytes)
+		if err = gob.NewDecoder(cachedBuffer).Decode(msg); err != nil {
+			logging.LogError("Error deserializing multiline message.\n", err)
+			return false
+		}
+		sort.Sort(msg.MsgLines)
+	} else {
+		msg = nil
+	}
+
+	if isStackTraceStart || isStackTraceMiddle {
+
+		var buffer bytes.Buffer
+
+		if msg == nil {
+			msg = e.createMultiLineMessage(isStackTraceStart)
+		} else {
+			numCachedLines := len(msg.MsgLines)
+			if numCachedLines > 0 && isStackTraceStart && msg.MsgLines[numCachedLines-1].Timestamp < timestamp {
+				if msg.Fields["timestamp"] != nil {
+					log.ShipEvents(msg.Fields, msg.MergeLines())
+				}
+				caching.DeleteMultiLineMessage(cfAppID.(string), cfAppIndex.(string))
+			}
+			e.addToMultiLineMessage(isStackTraceStart, msg)
+		}
+
+		if err = gob.NewEncoder(&buffer).Encode(msg); err != nil {
+			logging.LogError("Error serializing multiline message.\n", err)
+			return false
+		}
+
+		caching.PutMultiLineMessage(cfAppID.(string), cfAppIndex.(string), buffer.Bytes())
+		return true
+	}
+
+	if msg != nil {
+		if ts := msg.Fields["timestamp"]; ts != nil && ts.(int64) < timestamp {
+			log.ShipEvents(msg.Fields, msg.MergeLines())
+			caching.DeleteMultiLineMessage(cfAppID.(string), cfAppIndex.(string))
+		}
+	}
+
+	return false
+}
+
+func (e *Event) createMultiLineMessage(isStackTraceStart bool) *MultiLineMessage {
+
+	if isStackTraceStart {
+		return &MultiLineMessage{*e, make([]MsgLine, 0)}
+	}
+
+	msgLines := []MsgLine{
+		{
+			Timestamp: e.Fields["timestamp"].(int64),
+			Msg:       e.Msg,
+		},
+	}
+	return &MultiLineMessage{
+		MsgLines: msgLines,
+	}
+}
+
+func (e *Event) addToMultiLineMessage(isStackTraceStart bool, msg *MultiLineMessage) {
+
+	if isStackTraceStart {
+		msg.Fields = e.Fields
+		msg.Msg = e.Msg
+		msg.Type = e.Type
+	} else {
+		msg.MsgLines = append(msg.MsgLines, MsgLine{e.Fields["timestamp"].(int64), e.Msg})
+	}
+}
+
+func (msg *MultiLineMessage) MergeLines() string {
+
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("%s\n", msg.Msg))
+	for _, msgLine := range msg.MsgLines {
+		buffer.WriteString(fmt.Sprintf("%s\n", msgLine.Msg))
+	}
+	return buffer.String()
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var (
 	modeProf           = kingpin.Flag("mode-prof", "Enable profiling mode, one of [cpu, mem, block]").Default("").OverrideDefaultFromEnvar("MODE_PROF").String()
 	pathProf           = kingpin.Flag("path-prof", "Set the Path to write profiling file").Default("").OverrideDefaultFromEnvar("PATH_PROF").String()
 	logFormatterType   = kingpin.Flag("log-formatter-type", "Log formatter type to use. Valid options are text, json. If none provided, defaults to json.").Envar("LOG_FORMATTER_TYPE").String()
+	mergeStackTraces   = kingpin.Flag("merge-stacktraces", "Detect multi-line Java stack trace events and merge them into a single event.").Default("false").OverrideDefaultFromEnvar("MERGE_STACKTRACES").Bool()
 )
 
 var (
@@ -82,7 +83,7 @@ func main() {
 		cachingClient = caching.NewCachingEmpty()
 	}
 	//Creating Events
-	events := eventRouting.NewEventRouting(cachingClient, loggingClient)
+	events := eventRouting.NewEventRouting(cachingClient, loggingClient, *mergeStackTraces)
 	err := events.SetupEventRouting(*wantedEvents)
 	if err != nil {
 		log.Fatal("Error setting up event routing: ", err)


### PR DESCRIPTION
This update will merge Java stack trace lines that come through as multiple firehose events into a single event with the stack trace ordered and formatted so that it will readable when displayed in a tool like Kibana.
