### PR TITLE
Tidy up logging

### DIFF
--- a/firehoseclient/firehoseclient.go
+++ b/firehoseclient/firehoseclient.go
@@ -74,16 +74,16 @@ func (f *FirehoseNozzle) handleError(err error) {
 
 	switch {
 	case websocket.IsCloseError(err, websocket.CloseNormalClosure):
-		logging.LogError("Normal Websocket Closure: %v", err)
+		logging.LogError("Normal Websocket Closure", err)
 	case websocket.IsCloseError(err, websocket.ClosePolicyViolation):
-		logging.LogError("Error while reading from the firehose: %v", err)
+		logging.LogError("Error while reading from the firehose", err)
 		logging.LogError("Disconnected because nozzle couldn't keep up. Please try scaling up the nozzle.", nil)
 
 	default:
-		logging.LogError("Error while reading from the firehose: %v", err)
+		logging.LogError("Error while reading from the firehose", err)
 	}
 
-	logging.LogError("Closing connection with traffic controller due to %v", err)
+	logging.LogError("Closing connection with traffic controller due to error", err)
 	f.consumer.Close()
 }
 

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	//Enable LogsTotalevent
 	if *logEventTotals {
-		logging.LogStd("Logging total events %", true)
+		logging.LogStd("Logging total events", true)
 		events.LogEventTotals(*logEventTotalsTime)
 	}
 


### PR DESCRIPTION
While attempting to use this device, i got the following logging:

```
[2016-10-20 15:12:39.597611248 +0100 BST] Exception occurred! Message: Error while reading from the firehose: %v Details: Error dialing trafficcontroller server: malformed ws or wss URL.
Please ask your Cloud Foundry Operator to check the platform configuration (trafficcontroller is ).
[2016-10-20 15:12:39.597615598 +0100 BST] Exception occurred! Message: Closing connection with traffic controller due to %v Details: Error dialing trafficcontroller server: malformed ws or wss URL.
```

Note the raw `%v`s. It turns out there were a few places in the code where error log strings contained what appear to be attempts at format specifiers. The logging methods do not treat the log message as a format string, so these are useless. This PR removes them.
