### PR TITLE
Set health check to 'process'

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Showing top 10 nodes out of 44 (cum >= 20ms)
     ```
 1. Turn off the health check if you're staging to Diego.
     ```
-    cf set-health-check firehose-to-syslog none
+    cf set-health-check firehose-to-syslog process
     ```
 1. Push the app.
     ```


### PR DESCRIPTION
It seems the desired health check changed from `none` to `process`: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#health-check-type